### PR TITLE
feat(mcp): add OpenAPI HTTP transport with cursor support

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -52,3 +52,38 @@ From Docker:
   }
 }
 ```
+
+## Running as an HTTP server
+
+In addition to the standard stdio-based transport, the CLI can expose the MCP
+tools through a lightweight OpenAPI surface that returns JSON responses. This
+mode is designed for integrations such as Open WebUI that expect OpenAPI
+metadata (including a `cursor` verb) instead of the MCP streamable transport.
+
+Start the HTTP server by passing the `--openapi` flag (or by setting the
+environment variable `KARAKEEP_MCP_TRANSPORT=openapi`). The legacy `--http`
+flag still works as an alias.
+
+```
+karakeep-mcp --openapi --port 3333 --host 0.0.0.0 --path /mcp
+```
+
+By default the server listens on `0.0.0.0:3000` and exposes its endpoints under
+`/mcp`. The following options/environment variables are supported:
+
+- `--port` / `KARAKEEP_MCP_PORT` (or `PORT`): change the listening port.
+- `--host` / `KARAKEEP_MCP_HOST`: change the host/interface.
+- `--path` / `KARAKEEP_MCP_PATH`: change the base path for HTTP requests.
+- `--transport` / `KARAKEEP_MCP_TRANSPORT`: choose between `stdio` and
+  `openapi`.
+
+When running in OpenAPI mode, the server serves:
+
+- `${path}/openapi.json` – the OpenAPI schema describing all bookmark, list,
+  and tag operations, with JSON request/response payloads.
+- `${path}/openapi.conf` – a helper configuration file for Open WebUI that
+  maps operations (including the `cursor` verb) to their OpenAPI
+  `operationId`s.
+
+All HTTP responses include structured JSON, so no external shim is required to
+consume the tool results.

--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -1,16 +1,184 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
-import { karakeepClient, mcpServer, turndownService } from "./shared";
-import { compactBookmark, toMcpToolError } from "./utils";
+import { karakeepClient, turndownService } from "./shared";
+import {
+  BookmarkSummary,
+  compactBookmark,
+  extractApiError,
+  ServiceError,
+  toBookmarkSummary,
+  toMcpToolError,
+} from "./utils";
 
-// Tools
-mcpServer.tool(
-  "search-bookmarks",
-  `Search for bookmarks matching a specific a query.
+export const SearchBookmarksInputSchema = z.object({
+  query: z.string(),
+  limit: z.number().int().positive().max(100).optional().default(10),
+  nextCursor: z.string().optional(),
+});
+
+export type SearchBookmarksInput = z.infer<typeof SearchBookmarksInputSchema>;
+
+export interface SearchBookmarksResult {
+  bookmarks: BookmarkSummary[];
+  nextCursor: string | null;
+}
+
+export const GetBookmarkInputSchema = z.object({
+  bookmarkId: z.string(),
+});
+
+export type GetBookmarkInput = z.infer<typeof GetBookmarkInputSchema>;
+
+export const CreateBookmarkInputSchema = z.object({
+  type: z.enum(["link", "text"]),
+  title: z.string().optional(),
+  content: z.string(),
+});
+
+export type CreateBookmarkInput = z.infer<typeof CreateBookmarkInputSchema>;
+
+export const GetBookmarkContentInputSchema = z.object({
+  bookmarkId: z.string(),
+});
+
+export type GetBookmarkContentInput = z.infer<
+  typeof GetBookmarkContentInputSchema
+>;
+
+export interface BookmarkContentResult {
+  format: "markdown";
+  content: string;
+}
+
+export async function searchBookmarks(
+  input: SearchBookmarksInput,
+): Promise<SearchBookmarksResult> {
+  const res = await karakeepClient.GET("/bookmarks/search", {
+    params: {
+      query: {
+        q: input.query,
+        limit: input.limit,
+        includeContent: false,
+        cursor: input.nextCursor,
+      },
+    },
+  });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to search bookmarks", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
+    });
+  }
+
+  return {
+    bookmarks: res.data.bookmarks.map(toBookmarkSummary),
+    nextCursor: res.data.nextCursor,
+  };
+}
+
+export async function getBookmark(
+  input: GetBookmarkInput,
+): Promise<BookmarkSummary> {
+  const res = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
+    params: {
+      path: { bookmarkId: input.bookmarkId },
+      query: { includeContent: false },
+    },
+  });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to load bookmark", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 404,
+    });
+  }
+
+  return toBookmarkSummary(res.data);
+}
+
+export async function createBookmark(
+  input: CreateBookmarkInput,
+): Promise<BookmarkSummary> {
+  const res = await karakeepClient.POST(`/bookmarks`, {
+    body:
+      input.type === "link"
+        ? {
+            type: "link",
+            url: input.content,
+            title: input.title,
+          }
+        : {
+            type: "text",
+            text: input.content,
+            title: input.title,
+          },
+  });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to create bookmark", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
+    });
+  }
+
+  return toBookmarkSummary(res.data);
+}
+
+export async function getBookmarkContent(
+  input: GetBookmarkContentInput,
+): Promise<BookmarkContentResult> {
+  const res = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
+    params: {
+      path: { bookmarkId: input.bookmarkId },
+      query: { includeContent: true },
+    },
+  });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(
+      apiError?.message ?? "Failed to load bookmark content",
+      {
+        code: apiError?.code,
+        details: apiError?.raw ?? res,
+        status: 404,
+      },
+    );
+  }
+
+  let content = "";
+  if (res.data.content.type === "link") {
+    content = res.data.content.htmlContent
+      ? turndownService.turndown(res.data.content.htmlContent)
+      : "";
+  } else if (res.data.content.type === "text") {
+    content = res.data.content.text;
+  } else if (res.data.content.type === "asset") {
+    content = res.data.content.content ?? "";
+  }
+
+  return {
+    format: "markdown",
+    content,
+  };
+}
+
+export function registerBookmarkTools(server: McpServer) {
+  server.tool(
+    "search-bookmarks",
+    `Search for bookmarks matching a specific a query.
 `,
-  {
-    query: z.string().describe(`
+    {
+      query: z.string().describe(`
     By default, this will do a full-text search, but you can also use qualifiers to filter the results.
 You can search bookmarks using specific qualifiers. is:fav finds favorited bookmarks,
 is:archived searches archived bookmarks, is:tagged finds those with tags,
@@ -29,157 +197,131 @@ is:archived and (list:reading or #work)
 
 ### Combine text search with qualifiers
 machine learning is:fav`),
-    limit: z
-      .number()
-      .optional()
-      .describe(`The number of results to return in a single query.`)
-      .default(10),
-    nextCursor: z
-      .string()
-      .optional()
-      .describe(
-        `The next cursor to use for pagination. The value for this is returned from a previous call to this tool.`,
-      ),
-  },
-  async ({ query, limit, nextCursor }): Promise<CallToolResult> => {
-    const res = await karakeepClient.GET("/bookmarks/search", {
-      params: {
-        query: {
-          q: query,
-          limit: limit,
-          includeContent: false,
-          cursor: nextCursor,
-        },
-      },
-    });
-    if (!res.data) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `
-${res.data.bookmarks.map(compactBookmark).join("\n\n")}
-
-Next cursor: ${res.data.nextCursor ? `'${res.data.nextCursor}'` : "no more pages"}
-`,
-        },
-      ],
-    };
-  },
-);
-
-mcpServer.tool(
-  "get-bookmark",
-  `Get a bookmark by id.`,
-  {
-    bookmarkId: z.string().describe(`The bookmarkId to get.`),
-  },
-  async ({ bookmarkId }): Promise<CallToolResult> => {
-    const res = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
-      params: {
-        path: {
-          bookmarkId,
-        },
-        query: {
-          includeContent: false,
-        },
-      },
-    });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: compactBookmark(res.data),
-        },
-      ],
-    };
-  },
-);
-
-mcpServer.tool(
-  "create-bookmark",
-  `Create a link bookmark or a text bookmark`,
-  {
-    type: z.enum(["link", "text"]).describe(`The type of bookmark to create.`),
-    title: z.string().optional().describe(`The title of the bookmark`),
-    content: z
-      .string()
-      .describe(
-        "If type is text, the text to be bookmarked. If the type is link, then it's the URL to be bookmarked.",
-      ),
-  },
-  async ({ title, type, content }): Promise<CallToolResult> => {
-    const res = await karakeepClient.POST(`/bookmarks`, {
-      body: (
-        {
-          link: {
-            type: "link",
-            title,
-            url: content,
+      limit: z
+        .number()
+        .optional()
+        .describe(`The number of results to return in a single query.`)
+        .default(10),
+      nextCursor: z
+        .string()
+        .optional()
+        .describe(
+          `The next cursor to use for pagination. The value for this is returned from a previous call to this tool.`,
+        ),
+    },
+    async ({ query, limit, nextCursor }): Promise<CallToolResult> => {
+      try {
+        const result = await searchBookmarks({ query, limit, nextCursor });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.bookmarks
+                .map((bookmark) => compactBookmark(bookmark))
+                .join(
+                  "\n\n",
+                )}\n\nNext cursor: ${result.nextCursor ? `'${result.nextCursor}'` : "no more pages"}`,
+            },
+          ],
+          structuredContent: {
+            bookmarks: result.bookmarks,
+            nextCursor: result.nextCursor,
           },
-          text: {
-            type: "text",
-            title,
-            text: content,
-          },
-        } as const
-      )[type],
-    });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: compactBookmark(res.data),
-        },
-      ],
-    };
-  },
-);
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
 
-mcpServer.tool(
-  "get-bookmark-content",
-  `Get the content of the bookmark in markdown`,
-  {
-    bookmarkId: z.string().describe(`The bookmarkId to get content for.`),
-  },
-  async ({ bookmarkId }): Promise<CallToolResult> => {
-    const res = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
-      params: {
-        path: {
-          bookmarkId,
-        },
-        query: {
-          includeContent: true,
-        },
-      },
-    });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    let content;
-    if (res.data.content.type === "link") {
-      const htmlContent = res.data.content.htmlContent;
-      content = turndownService.turndown(htmlContent);
-    } else if (res.data.content.type === "text") {
-      content = res.data.content.text;
-    } else if (res.data.content.type === "asset") {
-      content = res.data.content.content;
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: content ?? "",
-        },
-      ],
-    };
-  },
-);
+  server.tool(
+    "get-bookmark",
+    `Get a bookmark by id.`,
+    {
+      bookmarkId: z.string().describe(`The bookmarkId to get.`),
+    },
+    async ({ bookmarkId }): Promise<CallToolResult> => {
+      try {
+        const summary = await getBookmark({ bookmarkId });
+        return {
+          content: [
+            {
+              type: "text",
+              text: compactBookmark(summary),
+            },
+          ],
+          structuredContent: {
+            bookmark: summary,
+          },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "create-bookmark",
+    `Create a link bookmark or a text bookmark`,
+    {
+      type: z
+        .enum(["link", "text"])
+        .describe(`The type of bookmark to create.`),
+      title: z.string().optional().describe(`The title of the bookmark`),
+      content: z
+        .string()
+        .describe(
+          "If type is text, the text to be bookmarked. If the type is link, then it's the URL to be bookmarked.",
+        ),
+    },
+    async ({ title, type, content }): Promise<CallToolResult> => {
+      try {
+        const summary = await createBookmark({
+          title,
+          type,
+          content,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: compactBookmark(summary),
+            },
+          ],
+          structuredContent: {
+            bookmark: summary,
+          },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "get-bookmark-content",
+    `Get the content of the bookmark in markdown`,
+    {
+      bookmarkId: z.string().describe(`The bookmarkId to get content for.`),
+    },
+    async ({ bookmarkId }): Promise<CallToolResult> => {
+      try {
+        const result = await getBookmarkContent({ bookmarkId });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.content,
+            },
+          ],
+          structuredContent: {
+            bookmarkId,
+            content: result,
+          },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,16 +1,476 @@
 #!/usr/bin/env node
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ZodError } from "zod";
 
-import { mcpServer } from "./shared";
+import {
+  createBookmark,
+  CreateBookmarkInputSchema,
+  getBookmark,
+  getBookmarkContent,
+  GetBookmarkContentInputSchema,
+  GetBookmarkInputSchema,
+  searchBookmarks,
+  SearchBookmarksInputSchema,
+} from "./bookmarks";
+import {
+  addBookmarkToList,
+  BookmarkListMutationSchema,
+  createList,
+  CreateListInputSchema,
+  getLists,
+  removeBookmarkFromList,
+} from "./lists";
+import { buildOpenApiConfig, buildOpenApiSpec } from "./openapi";
+import { createMcpServer } from "./server";
+import {
+  attachTagsToBookmark,
+  detachTagsFromBookmark,
+  TagMutationInputSchema,
+} from "./tags";
+import { ServiceError } from "./utils";
 
-import "./bookmarks.ts";
-import "./lists.ts";
-import "./tags.ts";
+type TransportMode = "stdio" | "openapi";
 
-async function run() {
-  // Start receiving messages on stdin and sending messages on stdout
-  const transport = new StdioServerTransport();
-  await mcpServer.connect(transport);
+interface CliOptions {
+  mode: TransportMode;
+  port: number;
+  host: string;
+  path: string;
 }
 
-run();
+const DEFAULT_PORT = 3000;
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_PATH = "/mcp";
+
+function printHelp() {
+  console.log(`Usage: karakeep-mcp [options]
+
+Options:
+  --stdio              Force stdio transport (default)
+  --openapi            Start an HTTP server that exposes the MCP tools via OpenAPI
+  --http               Alias for --openapi (deprecated)
+  --transport <mode>   Explicitly choose "stdio" or "openapi"
+  --port <number>      Port for HTTP mode (default: ${DEFAULT_PORT})
+  --host <host>        Hostname for HTTP mode (default: ${DEFAULT_HOST})
+  --path <path>        Base path for HTTP endpoints (default: ${DEFAULT_PATH})
+  -h, --help           Show this message
+`);
+}
+
+function parseTransport(value: string | undefined): TransportMode {
+  if (!value) {
+    return "stdio";
+  }
+  const normalized = value.toLowerCase();
+  if (normalized === "stdio") {
+    return "stdio";
+  }
+  if (normalized === "http" || normalized === "openapi") {
+    return "openapi";
+  }
+  throw new Error(`Unknown transport mode: ${value}`);
+}
+
+function parsePort(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return parsed;
+}
+
+function normalizePath(value: string | undefined): string {
+  if (!value || value.trim() === "") {
+    return DEFAULT_PATH;
+  }
+  let normalized = value.trim();
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  let mode = parseTransport(process.env.KARAKEEP_MCP_TRANSPORT);
+  let port = parsePort(
+    process.env.KARAKEEP_MCP_PORT ?? process.env.PORT,
+    DEFAULT_PORT,
+  );
+  let host = process.env.KARAKEEP_MCP_HOST ?? DEFAULT_HOST;
+  let path = normalizePath(process.env.KARAKEEP_MCP_PATH ?? DEFAULT_PATH);
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+        break;
+      case "--openapi":
+      case "--http":
+        mode = "openapi";
+        break;
+      case "--stdio":
+        mode = "stdio";
+        break;
+      case "--transport": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --transport");
+        }
+        mode = parseTransport(value);
+        i += 1;
+        break;
+      }
+      case "--port":
+      case "--http-port": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --port");
+        }
+        port = parsePort(value, port);
+        i += 1;
+        break;
+      }
+      case "--host":
+      case "--http-host": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --host");
+        }
+        host = value;
+        i += 1;
+        break;
+      }
+      case "--path":
+      case "--http-path": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --path");
+        }
+        path = normalizePath(value);
+        i += 1;
+        break;
+      }
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+    }
+  }
+
+  return { mode, port, host, path };
+}
+
+function setCorsHeaders(res: ServerResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
+}
+
+function sendJson(res: ServerResponse, statusCode: number, body: unknown) {
+  if (res.headersSent) {
+    return;
+  }
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+async function parseJsonBody(req: IncomingMessage): Promise<unknown> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    req.on("data", (chunk) => {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    });
+
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    req.on("error", (error) => {
+      reject(error);
+    });
+  });
+}
+
+function handleHttpError(res: ServerResponse, error: unknown) {
+  if (error instanceof SyntaxError) {
+    setCorsHeaders(res);
+    sendJson(res, 400, {
+      error: {
+        message: "Invalid JSON payload",
+      },
+    });
+    return;
+  }
+
+  if (error instanceof ZodError) {
+    setCorsHeaders(res);
+    sendJson(res, 400, {
+      error: {
+        message: "Invalid request",
+        details: error.flatten(),
+      },
+    });
+    return;
+  }
+
+  if (error instanceof ServiceError) {
+    setCorsHeaders(res);
+    sendJson(res, error.status, {
+      error: {
+        message: error.message,
+        code: error.code,
+        status: error.status,
+        details: error.details,
+      },
+    });
+    return;
+  }
+
+  console.error("[Karakeep MCP] Unexpected HTTP error", error);
+  setCorsHeaders(res);
+  sendJson(res, 500, {
+    error: {
+      message: "Internal server error",
+    },
+  });
+}
+
+async function startOpenApiServer({ port, host, path }: CliOptions) {
+  const basePath = path === "/" ? "" : path;
+  const spec = buildOpenApiSpec(basePath);
+  const config = buildOpenApiConfig(basePath);
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      if (!req.url) {
+        setCorsHeaders(res);
+        sendJson(res, 400, {
+          error: { message: "Bad Request" },
+        });
+        return;
+      }
+
+      const hostHeader = req.headers.host ?? `${host}:${port}`;
+      const requestUrl = new URL(req.url, `http://${hostHeader}`);
+
+      if (req.method === "OPTIONS") {
+        setCorsHeaders(res);
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+
+      if (
+        basePath &&
+        (!requestUrl.pathname.startsWith(basePath) ||
+          (requestUrl.pathname.length > basePath.length &&
+            requestUrl.pathname[basePath.length] !== "/"))
+      ) {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return;
+      }
+
+      const relativePathRaw = basePath
+        ? requestUrl.pathname.slice(basePath.length)
+        : requestUrl.pathname;
+      const relativePath = relativePathRaw === "" ? "/" : relativePathRaw;
+      const segments = relativePath.split("/").filter(Boolean);
+
+      if (req.method === "GET" && relativePath === "/openapi.json") {
+        setCorsHeaders(res);
+        sendJson(res, 200, spec);
+        return;
+      }
+
+      if (req.method === "GET" && relativePath === "/openapi.conf") {
+        setCorsHeaders(res);
+        sendJson(res, 200, config);
+        return;
+      }
+
+      if (req.method === "GET" && relativePath === "/") {
+        setCorsHeaders(res);
+        sendJson(res, 200, {
+          status: "ok",
+          message: "Karakeep MCP OpenAPI endpoint",
+        });
+        return;
+      }
+
+      if (req.method === "POST" && relativePath === "/bookmarks/search") {
+        const body = await parseJsonBody(req);
+        const input = SearchBookmarksInputSchema.parse(body ?? {});
+        const result = await searchBookmarks(input);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "POST" && relativePath === "/bookmarks") {
+        const body = await parseJsonBody(req);
+        const input = CreateBookmarkInputSchema.parse(body ?? {});
+        const result = await createBookmark(input);
+        setCorsHeaders(res);
+        sendJson(res, 201, result);
+        return;
+      }
+
+      if (
+        req.method === "GET" &&
+        segments[0] === "bookmarks" &&
+        segments.length === 2
+      ) {
+        const bookmarkId = decodeURIComponent(segments[1]!);
+        const input = GetBookmarkInputSchema.parse({ bookmarkId });
+        const result = await getBookmark(input);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (
+        req.method === "GET" &&
+        segments[0] === "bookmarks" &&
+        segments.length === 3 &&
+        segments[2] === "content"
+      ) {
+        const bookmarkId = decodeURIComponent(segments[1]!);
+        const input = GetBookmarkContentInputSchema.parse({ bookmarkId });
+        const result = await getBookmarkContent(input);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "GET" && relativePath === "/lists") {
+        const result = await getLists();
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "POST" && relativePath === "/lists") {
+        const body = await parseJsonBody(req);
+        const input = CreateListInputSchema.parse(body ?? {});
+        const result = await createList(input);
+        setCorsHeaders(res);
+        sendJson(res, 201, result);
+        return;
+      }
+
+      if (
+        segments[0] === "lists" &&
+        segments.length === 4 &&
+        segments[2] === "bookmarks" &&
+        req.method === "POST"
+      ) {
+        const mutationInput = BookmarkListMutationSchema.parse({
+          listId: decodeURIComponent(segments[1]!),
+          bookmarkId: decodeURIComponent(segments[3]!),
+        });
+        const result = await addBookmarkToList(mutationInput);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (
+        segments[0] === "lists" &&
+        segments.length === 4 &&
+        segments[2] === "bookmarks" &&
+        req.method === "DELETE"
+      ) {
+        const mutationInput = BookmarkListMutationSchema.parse({
+          listId: decodeURIComponent(segments[1]!),
+          bookmarkId: decodeURIComponent(segments[3]!),
+        });
+        const result = await removeBookmarkFromList(mutationInput);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "POST" && relativePath === "/tags/attach") {
+        const body = await parseJsonBody(req);
+        const input = TagMutationInputSchema.parse(body ?? {});
+        const result = await attachTagsToBookmark(input);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "POST" && relativePath === "/tags/detach") {
+        const body = await parseJsonBody(req);
+        const input = TagMutationInputSchema.parse(body ?? {});
+        const result = await detachTagsFromBookmark(input);
+        setCorsHeaders(res);
+        sendJson(res, 200, result);
+        return;
+      }
+
+      res.statusCode = 404;
+      setCorsHeaders(res);
+      res.end("Not Found");
+    } catch (error) {
+      handleHttpError(res, error);
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(port, host, () => {
+      console.log(
+        `Karakeep MCP OpenAPI server listening on http://${host}:${port}${path === "/" ? "" : path}`,
+      );
+      resolve();
+    });
+  });
+}
+
+async function startStdioServer() {
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+async function run() {
+  const options = parseCliOptions(process.argv.slice(2));
+
+  if (options.mode === "openapi") {
+    await startOpenApiServer(options);
+    return;
+  }
+
+  await startStdioServer();
+}
+
+run().catch((error) => {
+  console.error("[Karakeep MCP] Failed to start server", error);
+  process.exit(1);
+});

--- a/apps/mcp/src/lists.ts
+++ b/apps/mcp/src/lists.ts
@@ -1,132 +1,271 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
-import { karakeepClient, mcpServer } from "./shared";
-import { toMcpToolError } from "./utils";
+import { karakeepClient } from "./shared";
+import {
+  extractApiError,
+  ListSummary,
+  ServiceError,
+  toListSummary,
+  toMcpToolError,
+} from "./utils";
 
-mcpServer.tool(
-  "get-lists",
-  `Retrieves a list of lists.`,
-  async (): Promise<CallToolResult> => {
-    const res = await karakeepClient.GET("/lists", {
-      params: {},
+export const ListIdSchema = z.string();
+
+export type ListId = z.infer<typeof ListIdSchema>;
+
+export const BookmarkListMutationSchema = z.object({
+  listId: ListIdSchema,
+  bookmarkId: z.string(),
+});
+
+export type BookmarkListMutationInput = z.infer<
+  typeof BookmarkListMutationSchema
+>;
+
+export const CreateListInputSchema = z.object({
+  name: z.string(),
+  icon: z.string(),
+  parentId: z.string().optional(),
+});
+
+export type CreateListInput = z.infer<typeof CreateListInputSchema>;
+
+export interface ListCollectionResult {
+  lists: ListSummary[];
+}
+
+export interface ListMutationResult {
+  listId: string;
+  bookmarkId?: string;
+  action: "added" | "removed" | "created";
+  message: string;
+  list?: ListSummary;
+}
+
+export async function getLists(): Promise<ListCollectionResult> {
+  const res = await karakeepClient.GET("/lists", { params: {} });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to load lists", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
     });
-    if (!res.data) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: res.data.lists
-            .map(
-              (list) => `List ID: ${list.id}
-Name: ${list.name}
-Icon: ${list.icon}
-Description: ${list.description ?? ""}
-Parent ID: ${list.parentId}`,
-            )
-            .join("\n\n"),
-        },
-      ],
-    };
-  },
-);
+  }
 
-mcpServer.tool(
-  "add-bookmark-to-list",
-  `Add a bookmark to a list.`,
-  {
-    listId: z.string().describe(`The listId to add the bookmark to.`),
-    bookmarkId: z.string().describe(`The bookmarkId to add.`),
-  },
-  async ({ listId, bookmarkId }): Promise<CallToolResult> => {
-    const res = await karakeepClient.PUT(
-      `/lists/{listId}/bookmarks/{bookmarkId}`,
-      {
-        params: {
-          path: {
-            listId,
-            bookmarkId,
-          },
+  return {
+    lists: res.data.lists.map(toListSummary),
+  };
+}
+
+export async function addBookmarkToList(
+  input: BookmarkListMutationInput,
+): Promise<ListMutationResult> {
+  const res = await karakeepClient.PUT(
+    `/lists/{listId}/bookmarks/{bookmarkId}`,
+    {
+      params: {
+        path: {
+          listId: input.listId,
+          bookmarkId: input.bookmarkId,
         },
+      },
+    },
+  );
+
+  if (res.error) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(
+      apiError?.message ?? "Failed to add bookmark to list",
+      {
+        code: apiError?.code,
+        details: apiError?.raw ?? res,
+        status: 400,
       },
     );
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Bookmark ${bookmarkId} added to list ${listId}`,
-        },
-      ],
-    };
-  },
-);
+  }
 
-mcpServer.tool(
-  "remove-bookmark-from-list",
-  `Remove a bookmark from a list.`,
-  {
-    listId: z.string().describe(`The listId to remove the bookmark from.`),
-    bookmarkId: z.string().describe(`The bookmarkId to remove.`),
-  },
-  async ({ listId, bookmarkId }): Promise<CallToolResult> => {
-    const res = await karakeepClient.DELETE(
-      `/lists/{listId}/bookmarks/{bookmarkId}`,
-      {
-        params: {
-          path: {
-            listId,
-            bookmarkId,
-          },
+  return {
+    listId: input.listId,
+    bookmarkId: input.bookmarkId,
+    action: "added",
+    message: `Bookmark ${input.bookmarkId} added to list ${input.listId}`,
+  };
+}
+
+export async function removeBookmarkFromList(
+  input: BookmarkListMutationInput,
+): Promise<ListMutationResult> {
+  const res = await karakeepClient.DELETE(
+    `/lists/{listId}/bookmarks/{bookmarkId}`,
+    {
+      params: {
+        path: {
+          listId: input.listId,
+          bookmarkId: input.bookmarkId,
         },
+      },
+    },
+  );
+
+  if (res.error) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(
+      apiError?.message ?? "Failed to remove bookmark from list",
+      {
+        code: apiError?.code,
+        details: apiError?.raw ?? res,
+        status: 400,
       },
     );
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Bookmark ${bookmarkId} removed from list ${listId}`,
-        },
-      ],
-    };
-  },
-);
+  }
 
-mcpServer.tool(
-  "create-list",
-  `Create a list.`,
-  {
-    name: z.string().describe(`The name of the list.`),
-    icon: z.string().describe(`The emoji icon of the list.`),
-    parentId: z
-      .string()
-      .optional()
-      .describe(`The parent list id of this list.`),
-  },
-  async ({ name, icon }): Promise<CallToolResult> => {
-    const res = await karakeepClient.POST("/lists", {
-      body: {
-        name,
-        icon,
-      },
+  return {
+    listId: input.listId,
+    bookmarkId: input.bookmarkId,
+    action: "removed",
+    message: `Bookmark ${input.bookmarkId} removed from list ${input.listId}`,
+  };
+}
+
+export async function createList(
+  input: CreateListInput,
+): Promise<ListMutationResult> {
+  const res = await karakeepClient.POST("/lists", {
+    body: {
+      name: input.name,
+      icon: input.icon,
+      parentId: input.parentId,
+    },
+  });
+
+  if (!res.data) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to create list", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
     });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `List ${name} created with id ${res.data.id}`,
-        },
-      ],
-    };
-  },
-);
+  }
+
+  const listSummary = toListSummary(res.data);
+
+  return {
+    listId: listSummary.id,
+    action: "created",
+    message: `List ${listSummary.name} created with id ${listSummary.id}`,
+    list: listSummary,
+  };
+}
+
+export function registerListTools(server: McpServer) {
+  server.tool(
+    "get-lists",
+    `Retrieves a list of lists.`,
+    async (): Promise<CallToolResult> => {
+      try {
+        const result = await getLists();
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.lists
+                .map(
+                  (list) =>
+                    `List ID: ${list.id}\nName: ${list.name}\nIcon: ${list.icon}\nDescription: ${list.description ?? ""}\nParent ID: ${list.parentId ?? ""}`,
+                )
+                .join("\n\n"),
+            },
+          ],
+          structuredContent: {
+            lists: result.lists,
+          },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "add-bookmark-to-list",
+    `Add a bookmark to a list.`,
+    {
+      listId: z.string().describe(`The listId to add the bookmark to.`),
+      bookmarkId: z.string().describe(`The bookmarkId to add.`),
+    },
+    async ({ listId, bookmarkId }): Promise<CallToolResult> => {
+      try {
+        const result = await addBookmarkToList({ listId, bookmarkId });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.message,
+            },
+          ],
+          structuredContent: { result },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "remove-bookmark-from-list",
+    `Remove a bookmark from a list.`,
+    {
+      listId: z.string().describe(`The listId to remove the bookmark from.`),
+      bookmarkId: z.string().describe(`The bookmarkId to remove.`),
+    },
+    async ({ listId, bookmarkId }): Promise<CallToolResult> => {
+      try {
+        const result = await removeBookmarkFromList({ listId, bookmarkId });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.message,
+            },
+          ],
+          structuredContent: { result },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "create-list",
+    `Create a list.`,
+    {
+      name: z.string().describe(`The name of the list.`),
+      icon: z.string().describe(`The emoji icon of the list.`),
+      parentId: z
+        .string()
+        .optional()
+        .describe(`The parent list id of this list.`),
+    },
+    async ({ name, icon, parentId }): Promise<CallToolResult> => {
+      try {
+        const result = await createList({ name, icon, parentId });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.message,
+            },
+          ],
+          structuredContent: { result },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+}

--- a/apps/mcp/src/openapi.ts
+++ b/apps/mcp/src/openapi.ts
@@ -1,0 +1,552 @@
+const bookmarkSummarySchema = {
+  type: "object",
+  required: [
+    "id",
+    "createdAt",
+    "modifiedAt",
+    "archived",
+    "favourited",
+    "type",
+    "tags",
+  ],
+  properties: {
+    id: { type: "string" },
+    createdAt: { type: "string", format: "date-time" },
+    modifiedAt: { type: ["string", "null"], format: "date-time" },
+    title: { type: ["string", "null"] },
+    summary: { type: ["string", "null"] },
+    note: { type: ["string", "null"] },
+    archived: { type: "boolean" },
+    favourited: { type: "boolean" },
+    taggingStatus: { type: ["string", "null"] },
+    summarizationStatus: { type: ["string", "null"] },
+    type: { type: "string", enum: ["link", "text", "asset", "unknown"] },
+    url: { type: ["string", "null"] },
+    description: { type: ["string", "null"] },
+    author: { type: ["string", "null"] },
+    publisher: { type: ["string", "null"] },
+    sourceUrl: { type: ["string", "null"] },
+    assetId: { type: ["string", "null"] },
+    assetType: { type: ["string", "null"] },
+    tags: { type: "array", items: { type: "string" } },
+  },
+  additionalProperties: false,
+} as const;
+
+const bookmarkContentSchema = {
+  type: "object",
+  required: ["format", "content"],
+  properties: {
+    format: { type: "string", enum: ["markdown"] },
+    content: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const searchBookmarksInputSchema = {
+  type: "object",
+  required: ["query"],
+  properties: {
+    query: { type: "string" },
+    limit: { type: "integer", minimum: 1, maximum: 100 },
+    nextCursor: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const searchBookmarksResultSchema = {
+  type: "object",
+  required: ["bookmarks", "nextCursor"],
+  properties: {
+    bookmarks: { type: "array", items: bookmarkSummarySchema },
+    nextCursor: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+const createBookmarkInputSchema = {
+  type: "object",
+  required: ["type", "content"],
+  properties: {
+    type: { type: "string", enum: ["link", "text"] },
+    title: { type: "string" },
+    content: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const listSummarySchema = {
+  type: "object",
+  required: ["id", "name", "icon", "parentId", "type", "public"],
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    description: { type: ["string", "null"] },
+    icon: { type: "string" },
+    parentId: { type: ["string", "null"] },
+    type: { type: "string" },
+    query: { type: ["string", "null"] },
+    public: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+const listCollectionResultSchema = {
+  type: "object",
+  required: ["lists"],
+  properties: {
+    lists: { type: "array", items: listSummarySchema },
+  },
+  additionalProperties: false,
+} as const;
+
+const createListInputSchema = {
+  type: "object",
+  required: ["name", "icon"],
+  properties: {
+    name: { type: "string" },
+    icon: { type: "string" },
+    parentId: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const listMutationResultSchema = {
+  type: "object",
+  required: ["listId", "action", "message"],
+  properties: {
+    listId: { type: "string" },
+    bookmarkId: { type: "string" },
+    action: { type: "string", enum: ["added", "removed", "created"] },
+    message: { type: "string" },
+    list: listSummarySchema,
+  },
+  additionalProperties: false,
+} as const;
+
+const tagMutationInputSchema = {
+  type: "object",
+  required: ["bookmarkId", "tags"],
+  properties: {
+    bookmarkId: { type: "string" },
+    tags: { type: "array", items: { type: "string" }, minItems: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+const tagMutationResultSchema = {
+  type: "object",
+  required: ["bookmarkId", "tags", "action", "message"],
+  properties: {
+    bookmarkId: { type: "string" },
+    tags: { type: "array", items: { type: "string" } },
+    action: { type: "string", enum: ["attached", "detached"] },
+    message: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const errorResponseSchema = {
+  type: "object",
+  required: ["error"],
+  properties: {
+    error: {
+      type: "object",
+      required: ["message"],
+      properties: {
+        message: { type: "string" },
+        code: { type: "string" },
+        status: { type: "integer" },
+      },
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+export function buildOpenApiSpec(basePath: string) {
+  const serverUrl = basePath === "" ? "/" : basePath;
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Karakeep MCP OpenAPI",
+      version: "1.0.0",
+      description:
+        "HTTP interface for Karakeep MCP tools, exposing bookmark, list, and tag operations with JSON responses.",
+    },
+    servers: [
+      {
+        url: serverUrl,
+      },
+    ],
+    components: {
+      schemas: {
+        BookmarkSummary: bookmarkSummarySchema,
+        BookmarkContentResult: bookmarkContentSchema,
+        SearchBookmarksInput: searchBookmarksInputSchema,
+        SearchBookmarksResult: searchBookmarksResultSchema,
+        CreateBookmarkInput: createBookmarkInputSchema,
+        ListSummary: listSummarySchema,
+        ListCollectionResult: listCollectionResultSchema,
+        CreateListInput: createListInputSchema,
+        ListMutationResult: listMutationResultSchema,
+        TagMutationInput: tagMutationInputSchema,
+        TagMutationResult: tagMutationResultSchema,
+        ErrorResponse: errorResponseSchema,
+      },
+    },
+    paths: {
+      "/bookmarks/search": {
+        post: {
+          operationId: "searchBookmarks",
+          summary: "Search bookmarks",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SearchBookmarksInput" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "A paginated list of bookmarks",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/SearchBookmarksResult",
+                  },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/bookmarks": {
+        post: {
+          operationId: "createBookmark",
+          summary: "Create a bookmark",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreateBookmarkInput" },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "The created bookmark",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/BookmarkSummary" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/bookmarks/{bookmarkId}": {
+        get: {
+          operationId: "getBookmark",
+          summary: "Get bookmark",
+          parameters: [
+            {
+              name: "bookmarkId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Bookmark details",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/BookmarkSummary" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/bookmarks/{bookmarkId}/content": {
+        get: {
+          operationId: "getBookmarkContent",
+          summary: "Get bookmark content",
+          parameters: [
+            {
+              name: "bookmarkId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Bookmark content in markdown",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/BookmarkContentResult",
+                  },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/lists": {
+        get: {
+          operationId: "listLists",
+          summary: "List available lists",
+          responses: {
+            "200": {
+              description: "Collection of lists",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ListCollectionResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+        post: {
+          operationId: "createList",
+          summary: "Create a new list",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreateListInput" },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "Created list",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ListMutationResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/lists/{listId}/bookmarks/{bookmarkId}": {
+        post: {
+          operationId: "addBookmarkToList",
+          summary: "Add bookmark to list",
+          parameters: [
+            {
+              name: "listId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "bookmarkId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Bookmark added",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ListMutationResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+        delete: {
+          operationId: "removeBookmarkFromList",
+          summary: "Remove bookmark from list",
+          parameters: [
+            {
+              name: "listId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "bookmarkId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Bookmark removed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ListMutationResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/tags/attach": {
+        post: {
+          operationId: "attachTags",
+          summary: "Attach tags to bookmark",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TagMutationInput" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Tags attached",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/TagMutationResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/tags/detach": {
+        post: {
+          operationId: "detachTags",
+          summary: "Detach tags from bookmark",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TagMutationInput" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Tags detached",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/TagMutationResult" },
+                },
+              },
+            },
+            default: {
+              description: "Error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const;
+}
+
+export function buildOpenApiConfig(basePath: string) {
+  const prefix = basePath === "" ? "" : basePath;
+  return {
+    name: "Karakeep MCP",
+    description: "Karakeep MCP OpenAPI surface compatible with Open WebUI.",
+    schema: `${prefix}/openapi.json`,
+    servers: [
+      {
+        url: prefix === "" ? "/" : prefix,
+      },
+    ],
+    operations: [
+      { operationId: "searchBookmarks", verb: "search" },
+      { operationId: "searchBookmarks", verb: "cursor" },
+      { operationId: "getBookmark", verb: "get" },
+      { operationId: "createBookmark", verb: "create" },
+      { operationId: "getBookmarkContent", verb: "get" },
+      { operationId: "listLists", verb: "list" },
+      { operationId: "createList", verb: "create" },
+      { operationId: "addBookmarkToList", verb: "update" },
+      { operationId: "removeBookmarkFromList", verb: "delete" },
+      { operationId: "attachTags", verb: "update" },
+      { operationId: "detachTags", verb: "update" },
+    ],
+  } as const;
+}

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -1,0 +1,18 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { registerBookmarkTools } from "./bookmarks";
+import { registerListTools } from "./lists";
+import { registerTagTools } from "./tags";
+
+export function createMcpServer() {
+  const server = new McpServer({
+    name: "Karakeep",
+    version: "0.23.0",
+  });
+
+  registerBookmarkTools(server);
+  registerListTools(server);
+  registerTagTools(server);
+
+  return server;
+}

--- a/apps/mcp/src/shared.ts
+++ b/apps/mcp/src/shared.ts
@@ -1,4 +1,3 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import TurndownService from "turndown";
 
 import { createKarakeepClient } from "@karakeep/sdk";
@@ -12,11 +11,6 @@ export const karakeepClient = createKarakeepClient({
     "Content-Type": "application/json",
     authorization: `Bearer ${apiKey}`,
   },
-});
-
-export const mcpServer = new McpServer({
-  name: "Karakeep",
-  version: "0.23.0",
 });
 
 export const turndownService = new TurndownService();

--- a/apps/mcp/src/tags.ts
+++ b/apps/mcp/src/tags.ts
@@ -1,69 +1,140 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
-import { karakeepClient, mcpServer } from "./shared";
-import { toMcpToolError } from "./utils";
+import { karakeepClient } from "./shared";
+import { extractApiError, ServiceError, toMcpToolError } from "./utils";
 
-mcpServer.tool(
-  "attach-tag-to-bookmark",
-  `Attach a tag to a bookmark.`,
-  {
-    bookmarkId: z.string().describe(`The bookmarkId to attach the tag to.`),
-    tagsToAttach: z.array(z.string()).describe(`The tag names to attach.`),
-  },
-  async ({ bookmarkId, tagsToAttach }): Promise<CallToolResult> => {
-    const res = await karakeepClient.POST(`/bookmarks/{bookmarkId}/tags`, {
-      params: {
-        path: {
-          bookmarkId,
-        },
-      },
-      body: {
-        tags: tagsToAttach.map((tag) => ({ tagName: tag })),
-      },
-    });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Tags ${JSON.stringify(tagsToAttach)} attached to bookmark ${bookmarkId}`,
-        },
-      ],
-    };
-  },
-);
+export const TagMutationInputSchema = z.object({
+  bookmarkId: z.string(),
+  tags: z.array(z.string()).min(1),
+});
 
-mcpServer.tool(
-  "detach-tag-from-bookmark",
-  `Detach a tag from a bookmark.`,
-  {
-    bookmarkId: z.string().describe(`The bookmarkId to detach the tag from.`),
-    tagsToDetach: z.array(z.string()).describe(`The tag names to detach.`),
-  },
-  async ({ bookmarkId, tagsToDetach }): Promise<CallToolResult> => {
-    const res = await karakeepClient.DELETE(`/bookmarks/{bookmarkId}/tags`, {
-      params: {
-        path: {
-          bookmarkId,
-        },
+export type TagMutationInput = z.infer<typeof TagMutationInputSchema>;
+
+export interface TagMutationResult {
+  bookmarkId: string;
+  tags: string[];
+  action: "attached" | "detached";
+  message: string;
+}
+
+export async function attachTagsToBookmark(
+  input: TagMutationInput,
+): Promise<TagMutationResult> {
+  const res = await karakeepClient.POST(`/bookmarks/{bookmarkId}/tags`, {
+    params: {
+      path: {
+        bookmarkId: input.bookmarkId,
       },
-      body: {
-        tags: tagsToDetach.map((tag) => ({ tagName: tag })),
-      },
+    },
+    body: {
+      tags: input.tags.map((tag) => ({ tagName: tag })),
+    },
+  });
+
+  if (res.error) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to attach tags", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
     });
-    if (res.error) {
-      return toMcpToolError(res.error);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Tags ${JSON.stringify(tagsToDetach)} detached from bookmark ${bookmarkId}`,
-        },
-      ],
-    };
-  },
-);
+  }
+
+  return {
+    bookmarkId: input.bookmarkId,
+    tags: input.tags,
+    action: "attached",
+    message: `Tags ${JSON.stringify(input.tags)} attached to bookmark ${input.bookmarkId}`,
+  };
+}
+
+export async function detachTagsFromBookmark(
+  input: TagMutationInput,
+): Promise<TagMutationResult> {
+  const res = await karakeepClient.DELETE(`/bookmarks/{bookmarkId}/tags`, {
+    params: {
+      path: {
+        bookmarkId: input.bookmarkId,
+      },
+    },
+    body: {
+      tags: input.tags.map((tag) => ({ tagName: tag })),
+    },
+  });
+
+  if (res.error) {
+    const apiError = extractApiError(res);
+    throw new ServiceError(apiError?.message ?? "Failed to detach tags", {
+      code: apiError?.code,
+      details: apiError?.raw ?? res,
+      status: 400,
+    });
+  }
+
+  return {
+    bookmarkId: input.bookmarkId,
+    tags: input.tags,
+    action: "detached",
+    message: `Tags ${JSON.stringify(input.tags)} detached from bookmark ${input.bookmarkId}`,
+  };
+}
+
+export function registerTagTools(server: McpServer) {
+  server.tool(
+    "attach-tag-to-bookmark",
+    `Attach a tag to a bookmark.`,
+    {
+      bookmarkId: z.string().describe(`The bookmarkId to attach the tag to.`),
+      tagsToAttach: z.array(z.string()).describe(`The tag names to attach.`),
+    },
+    async ({ bookmarkId, tagsToAttach }): Promise<CallToolResult> => {
+      try {
+        const result = await attachTagsToBookmark({
+          bookmarkId,
+          tags: tagsToAttach,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.message,
+            },
+          ],
+          structuredContent: { result },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+
+  server.tool(
+    "detach-tag-from-bookmark",
+    `Detach a tag from a bookmark.`,
+    {
+      bookmarkId: z.string().describe(`The bookmarkId to detach the tag from.`),
+      tagsToDetach: z.array(z.string()).describe(`The tag names to detach.`),
+    },
+    async ({ bookmarkId, tagsToDetach }): Promise<CallToolResult> => {
+      try {
+        const result = await detachTagsFromBookmark({
+          bookmarkId,
+          tags: tagsToDetach,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.message,
+            },
+          ],
+          structuredContent: { result },
+        };
+      } catch (error) {
+        return toMcpToolError(error);
+      }
+    },
+  );
+}

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -2,51 +2,221 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 
 import { KarakeepAPISchemas } from "@karakeep/sdk";
 
-export function toMcpToolError(
-  error: { code: string; message: string } | undefined,
-): CallToolResult {
+export class ServiceError extends Error {
+  status: number;
+  code?: string;
+  details?: unknown;
+
+  constructor(
+    message: string,
+    options?: {
+      status?: number;
+      code?: string;
+      details?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = "ServiceError";
+    this.status = options?.status ?? 500;
+    this.code = options?.code;
+    this.details = options?.details;
+  }
+}
+
+interface NormalizedError {
+  message: string;
+  code?: string;
+  status?: number;
+  details?: unknown;
+}
+
+export interface ApiErrorDetails {
+  code?: string;
+  message?: string;
+  raw?: unknown;
+}
+
+function normalizeError(error: unknown): NormalizedError {
+  if (!error) {
+    return { message: "Something went wrong" };
+  }
+
+  if (error instanceof ServiceError) {
+    return {
+      message: error.message,
+      code: error.code,
+      status: error.status,
+      details: error.details,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+    };
+  }
+
+  if (typeof error === "object") {
+    const message =
+      typeof (error as { message?: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : "Something went wrong";
+    const code =
+      typeof (error as { code?: unknown }).code === "string"
+        ? (error as { code: string }).code
+        : undefined;
+
+    return {
+      message,
+      code,
+      details: error,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
+export function toMcpToolError(error: unknown): CallToolResult {
+  const normalized = normalizeError(error);
   return {
     isError: true,
     content: [
       {
         type: "text",
-        text: error ? JSON.stringify(error) : `Something went wrong`,
+        text: JSON.stringify(normalized),
       },
     ],
+    structuredContent: {
+      error: normalized,
+    },
   };
 }
 
-export function compactBookmark(
+export function extractApiError(res: unknown): ApiErrorDetails | undefined {
+  if (!res || typeof res !== "object") {
+    return undefined;
+  }
+  if (!("error" in res)) {
+    return undefined;
+  }
+  const raw = (res as { error?: unknown }).error;
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const messageValue = (raw as { message?: unknown }).message;
+  const codeValue = (raw as { code?: unknown }).code;
+  return {
+    message: typeof messageValue === "string" ? messageValue : undefined,
+    code: typeof codeValue === "string" ? codeValue : undefined,
+    raw,
+  };
+}
+
+export interface BookmarkSummary {
+  id: string;
+  createdAt: string;
+  modifiedAt: string | null;
+  title: string | null | undefined;
+  summary: string | null | undefined;
+  note: string | null | undefined;
+  archived: boolean;
+  favourited: boolean;
+  taggingStatus: string | null | undefined;
+  summarizationStatus: string | null | undefined;
+  type: "link" | "text" | "asset" | "unknown";
+  url?: string | null;
+  description?: string | null;
+  author?: string | null;
+  publisher?: string | null;
+  sourceUrl?: string | null;
+  assetId?: string | null;
+  assetType?: string | null;
+  tags: string[];
+}
+
+export function toBookmarkSummary(
   bookmark: KarakeepAPISchemas["Bookmark"],
-): string {
-  let content: string;
-  if (bookmark.content.type === "link") {
-    content = `Bookmark type: link
-Bookmarked URL: ${bookmark.content.url}
-description: ${bookmark.content.description ?? ""}
-author: ${bookmark.content.author ?? ""}
-publisher: ${bookmark.content.publisher ?? ""}`;
-  } else if (bookmark.content.type === "text") {
-    content = `Bookmark type: text
-  Source URL: ${bookmark.content.sourceUrl ?? ""}`;
-  } else if (bookmark.content.type === "asset") {
-    content = `Bookmark type: media
-Asset ID: ${bookmark.content.assetId}
-Asset type: ${bookmark.content.assetType}
-Source URL: ${bookmark.content.sourceUrl ?? ""}`;
-  } else {
-    content = `Bookmark type: unknown`;
+): BookmarkSummary {
+  const summary: BookmarkSummary = {
+    id: bookmark.id,
+    createdAt: bookmark.createdAt,
+    modifiedAt: bookmark.modifiedAt,
+    title:
+      bookmark.title ??
+      (bookmark.content.type === "link"
+        ? (bookmark.content.title ?? null)
+        : null),
+    summary: bookmark.summary,
+    note: bookmark.note,
+    archived: bookmark.archived,
+    favourited: bookmark.favourited,
+    taggingStatus: bookmark.taggingStatus,
+    summarizationStatus: bookmark.summarizationStatus,
+    type: bookmark.content.type ?? "unknown",
+    tags: bookmark.tags.map((tag) => tag.name),
+  };
+
+  switch (bookmark.content.type) {
+    case "link":
+      summary.url = bookmark.content.url;
+      summary.description = bookmark.content.description ?? null;
+      summary.author = bookmark.content.author ?? null;
+      summary.publisher = bookmark.content.publisher ?? null;
+      break;
+    case "text":
+      summary.sourceUrl = bookmark.content.sourceUrl ?? null;
+      break;
+    case "asset":
+      summary.assetId = bookmark.content.assetId;
+      summary.assetType = bookmark.content.assetType;
+      summary.sourceUrl = bookmark.content.sourceUrl ?? null;
+      break;
+    default:
+      break;
   }
 
-  return `Bookmark ID: ${bookmark.id}
-  Created at: ${bookmark.createdAt}
-  Title: ${
-    bookmark.title
-      ? bookmark.title
-      : ((bookmark.content.type === "link" ? bookmark.content.title : "") ?? "")
-  }
-  Summary: ${bookmark.summary ?? ""}
-  Note: ${bookmark.note ?? ""}
-  ${content}
-  Tags: ${bookmark.tags.map((t) => t.name).join(", ")}`;
+  return summary;
+}
+
+export function compactBookmark(summary: BookmarkSummary): string {
+  const details = (() => {
+    switch (summary.type) {
+      case "link":
+        return `Bookmark type: link\nBookmarked URL: ${summary.url ?? ""}\ndescription: ${summary.description ?? ""}\nauthor: ${summary.author ?? ""}\npublisher: ${summary.publisher ?? ""}`;
+      case "text":
+        return `Bookmark type: text\nSource URL: ${summary.sourceUrl ?? ""}`;
+      case "asset":
+        return `Bookmark type: media\nAsset ID: ${summary.assetId ?? ""}\nAsset type: ${summary.assetType ?? ""}\nSource URL: ${summary.sourceUrl ?? ""}`;
+      default:
+        return `Bookmark type: unknown`;
+    }
+  })();
+
+  return `Bookmark ID: ${summary.id}\n  Created at: ${summary.createdAt}\n  Title: ${summary.title ?? ""}\n  Summary: ${summary.summary ?? ""}\n  Note: ${summary.note ?? ""}\n  ${details}\n  Tags: ${summary.tags.join(", ")}`;
+}
+
+export interface ListSummary {
+  id: string;
+  name: string;
+  description: string | null | undefined;
+  icon: string;
+  parentId: string | null;
+  type: string;
+  query: string | null | undefined;
+  public: boolean;
+}
+
+export function toListSummary(list: KarakeepAPISchemas["List"]): ListSummary {
+  return {
+    id: list.id,
+    name: list.name,
+    description: list.description,
+    icon: list.icon,
+    parentId: list.parentId,
+    type: list.type,
+    query: list.query,
+    public: list.public,
+  };
 }


### PR DESCRIPTION
## Summary
- replace the prior streamable HTTP mode with an OpenAPI-based server that serves JSON endpoints, `openapi.json`, and `openapi.conf` including a cursor verb for Open WebUI compatibility
- update bookmark, list, and tag tools to expose structured JSON results and improved error handling for both stdio and HTTP flows
- document the new `--openapi` CLI mode and configuration in the MCP README

## Testing
- pnpm --filter @karakeep/mcp lint
- pnpm --filter @karakeep/mcp typecheck
- pnpm --filter @karakeep/mcp format

------
https://chatgpt.com/codex/tasks/task_e_68c9cf188f6483249e49b8c0bad8e4be