### PR TITLE
Add Docker support for testing MCP server

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -53,6 +53,15 @@ From Docker:
 }
 ```
 
+### Local testing with Docker from source
+
+The repository includes a multi-stage Dockerfile under
+`apps/mcp/docker/Dockerfile` that builds the MCP server directly from the
+workspace. The Dockerfile provides placeholder values for `KARAKEEP_API_ADDR`
+and `KARAKEEP_API_KEY`, and you can override them by passing `-e` flags to
+`docker run`. Follow the [Docker README](./docker/README.md) for commands that
+build the image and run it in OpenAPI or stdio mode.
+
 ## Running as an HTTP server
 
 In addition to the standard stdio-based transport, the CLI can expose the MCP

--- a/apps/mcp/docker/Dockerfile
+++ b/apps/mcp/docker/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM node:22-alpine AS base
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+WORKDIR /app
+
+RUN corepack enable \
+  && apk add --no-cache libc6-compat python3 make g++
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/mcp/package.json apps/mcp/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY tooling/prettier/package.json tooling/prettier/package.json
+COPY tooling/typescript/package.json tooling/typescript/package.json
+
+RUN pnpm install --filter @karakeep/mcp... --frozen-lockfile
+
+FROM base AS build
+
+COPY apps/mcp apps/mcp
+COPY packages/sdk packages/sdk
+COPY tooling/prettier tooling/prettier
+COPY tooling/typescript tooling/typescript
+
+RUN pnpm --filter @karakeep/sdk... build
+RUN pnpm --filter @karakeep/mcp... build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+ENV KARAKEEP_API_ADDR=https://demo.karakeep.local
+ENV KARAKEEP_API_KEY=demo-api-key
+
+COPY --from=build /app/apps/mcp/dist ./dist
+
+EXPOSE 3333
+
+ENTRYPOINT ["node", "dist/index.js"]
+CMD ["--openapi", "--port", "3333", "--host", "0.0.0.0"]

--- a/apps/mcp/docker/README.md
+++ b/apps/mcp/docker/README.md
@@ -1,0 +1,45 @@
+# Docker testing image for the Karakeep MCP server
+
+This directory contains a standalone Dockerfile that builds the `@karakeep/mcp`
+package and bakes default API credentials into the resulting container. The
+image is intended for local testing of the MCP tools without needing to install
+Node.js or pnpm on the host machine. The Dockerfile sets placeholder values for
+`KARAKEEP_API_ADDR` and `KARAKEEP_API_KEY`, but you should pass real credentials
+when running the container.
+
+## Building the image
+
+```bash
+docker build \
+  -f apps/mcp/docker/Dockerfile \
+  -t karakeep-mcp-test \
+  .
+```
+
+## Running the MCP server
+
+The container defaults to starting the MCP server in OpenAPI mode on port 3333.
+Expose the port to your host and supply the Karakeep API credentials as
+environment variables when running the image.
+
+```bash
+docker run --rm \
+  -p 3333:3333 \
+  -e KARAKEEP_API_ADDR=https://api.example.com \
+  -e KARAKEEP_API_KEY=another-token \
+  karakeep-mcp-test
+```
+
+If you are testing with the demo service, you can rely on the baked-in defaults
+and omit the `-e` flags.
+
+If you prefer to interact with the MCP server over stdio, override the default
+command and keep the container attached to your terminal.
+
+```bash
+docker run --rm -it karakeep-mcp-test --stdio
+```
+
+With the server running, you can point compatible MCP clients (for example,
+Claude Desktop or Open WebUI) at `http://localhost:3333/mcp` to exercise the
+Karakeep tooling.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the MCP package that builds from the monorepo, provides placeholder Karakeep API credentials, and starts in OpenAPI mode for containerized testing
- document how to build and run the MCP server image for local testing with Docker, supplying Karakeep credentials via `docker run` environment variables
- cross-link the MCP README to the new Docker testing instructions

## Testing
- `pnpm turbo run --no-daemon typecheck lint format`


------
https://chatgpt.com/codex/tasks/task_e_68cb08134b388324af5f5c41bea7c516