### PR TITLE
Fix MCP Docker build by copying patches directory

### DIFF
--- a/apps/mcp/docker/Dockerfile
+++ b/apps/mcp/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN corepack enable \
   && apk add --no-cache libc6-compat python3 make g++
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY patches patches
 COPY apps/mcp/package.json apps/mcp/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY tooling/prettier/package.json tooling/prettier/package.json

--- a/apps/mcp/docker/README.md
+++ b/apps/mcp/docker/README.md
@@ -13,7 +13,7 @@ when running the container.
 ```bash
 docker build \
   -f apps/mcp/docker/Dockerfile \
-  -t karakeep-mcp-test \
+  -t karakeep-mcp-openapi \
   .
 ```
 
@@ -28,7 +28,7 @@ docker run --rm \
   -p 3333:3333 \
   -e KARAKEEP_API_ADDR=https://api.example.com \
   -e KARAKEEP_API_KEY=another-token \
-  karakeep-mcp-test
+  karakeep-mcp-openapi
 ```
 
 If you are testing with the demo service, you can rely on the baked-in defaults
@@ -38,7 +38,7 @@ If you prefer to interact with the MCP server over stdio, override the default
 command and keep the container attached to your terminal.
 
 ```bash
-docker run --rm -it karakeep-mcp-test --stdio
+docker run --rm -it karakeep-mcp-openapi --stdio
 ```
 
 With the server running, you can point compatible MCP clients (for example,


### PR DESCRIPTION
## Summary
- copy the repository patches directory into the MCP Docker build context so pnpm patch files are available during install
- update the MCP Docker README to reference the new `karakeep-mcp-openapi` image tag

## Testing
- turbo run --no-daemon typecheck lint format

------
https://chatgpt.com/codex/tasks/task_e_68cb154dfccc8324bc540bf308d3d7ae