### PR TITLE
Adjust OpenAPI server defaults

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -41,7 +41,7 @@ interface CliOptions {
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_HOST = "0.0.0.0";
-const DEFAULT_PATH = "/mcp";
+const DEFAULT_PATH = "/";
 
 const DEBUG_ENV_VAR = "KARAKEEP_MCP_DEBUG";
 const MAX_DEBUG_LEVEL = 2;
@@ -451,8 +451,19 @@ async function startOpenApiServer({ port, host, path }: CliOptions) {
         return;
       }
 
-      if (req.method === "GET" && relativePath === "/openapi.json") {
+      if (
+        relativePath === "/openapi.json" &&
+        (req.method === "GET" || req.method === "POST" || req.method === "HEAD")
+      ) {
         setCorsHeaders(res);
+        if (req.method === "HEAD") {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          logOpenApiResponse(context, 200, null);
+          res.end();
+          return;
+        }
+
         sendJson(res, 200, spec, context);
         return;
       }


### PR DESCRIPTION
## Summary
- change the OpenAPI server default base path to "/" so it no longer appends "/mcp" when starting
- allow GET, POST, and HEAD requests for `/openapi.json`, responding with the OpenAPI document even when a POST is used

## Testing
- pnpm --filter @karakeep/mcp typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc336b9e2c83249678fa66d3720e3f