### PR TITLE
Align Karakeep MCP OpenAPI search payload with Open WebUI expectations

### DIFF
--- a/apps/mcp/src/openapi.ts
+++ b/apps/mcp/src/openapi.ts
@@ -50,16 +50,19 @@ const searchBookmarksInputSchema = {
     query: { type: "string" },
     limit: { type: "integer", minimum: 1, maximum: 100 },
     nextCursor: { type: "string" },
+    cursor: { type: "string" },
   },
   additionalProperties: false,
 } as const;
 
 const searchBookmarksResultSchema = {
   type: "object",
-  required: ["bookmarks", "nextCursor", "text"],
+  required: ["bookmarks", "items", "nextCursor", "cursor", "text"],
   properties: {
     bookmarks: { type: "array", items: bookmarkSummarySchema },
+    items: { type: "array", items: bookmarkSummarySchema },
     nextCursor: { type: ["string", "null"] },
+    cursor: { type: ["string", "null"] },
     text: { type: "string" },
   },
   additionalProperties: false,


### PR DESCRIPTION
## Summary
- add cursor alias support to the search input schema to accept either nextCursor or cursor
- include cursor/items aliases in search responses and propagate them through the MCP structured content
- update the OpenAPI schema to advertise the new request and response fields expected by Open WebUI

## Testing
- pnpm --filter @karakeep/mcp lint
- pnpm --filter @karakeep/mcp typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1bde4101c8324a24b3729bb16840a