### PR TITLE
Fix cursor echo in search bookmarks

### DIFF
--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -19,7 +19,6 @@ export const SearchBookmarksInputSchema = z
     limit: z.number().int().positive().max(100).optional().default(10),
     nextCursor: z.string().nullable().optional(),
     cursor: z.string().nullable().optional(),
-
   })
   .refine((value) => !(value.nextCursor && value.cursor), {
     message: "Provide either nextCursor or cursor, not both.",
@@ -74,7 +73,7 @@ export interface BookmarkContentResult {
 export async function searchBookmarks(
   input: SearchBookmarksInput,
 ): Promise<SearchBookmarksResult> {
-  const cursor = input.nextCursor ?? input.cursor;
+  const cursor = input.nextCursor ?? input.cursor ?? null;
   const res = await karakeepClient.GET("/bookmarks/search", {
     params: {
       query: {
@@ -101,7 +100,7 @@ export async function searchBookmarks(
   const paginatedData = {
     items: bookmarks,
     nextCursor,
-    cursor: nextCursor,
+    cursor,
     hasMore,
   } as const;
 
@@ -110,7 +109,7 @@ export async function searchBookmarks(
     items: bookmarks,
     results: bookmarks,
     nextCursor,
-    cursor: nextCursor,
+    cursor,
     hasMore,
     data: paginatedData,
     text: formatBookmarkSearchResult(bookmarks, nextCursor, input.query),


### PR DESCRIPTION
## Summary
- ensure `searchBookmarks` returns the cursor that was requested instead of the next page cursor
- include the request cursor in the nested `data` payload alongside the next cursor metadata

## Testing
- turbo run --no-daemon typecheck lint format

------
https://chatgpt.com/codex/tasks/task_e_68d258ded0e483248400751d07195a83