### PR TITLE
Refine MCP logging and document search query language in OpenAPI

### DIFF
--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -3,6 +3,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
 import { logDebug, withToolLogging } from "./logging";
+import { SEARCH_QUERY_LANGUAGE_DESCRIPTION } from "./search-query-docs";
 import { karakeepClient, turndownService } from "./shared";
 import {
   BookmarkSummary,
@@ -221,28 +222,9 @@ export async function getBookmarkContent(
 export function registerBookmarkTools(server: McpServer) {
   server.tool(
     "search-bookmarks",
-    `Search for bookmarks matching a specific a query.
-`,
+    `Search for bookmarks with Karakeep's query language.`,
     {
-      query: z.string().describe(`
-    By default, this will do a full-text search, but you can also use qualifiers to filter the results.
-You can search bookmarks using specific qualifiers. is:fav finds favorited bookmarks,
-is:archived searches archived bookmarks, is:tagged finds those with tags,
-is:inlist finds those in lists, and is:link, is:text, and is:media filter by bookmark type.
-url:<value> searches for URL substrings, #<tag> searches for bookmarks with a specific tag,
-list:<name> searches for bookmarks in a specific list given its name (without the icon),
-after:<date> finds bookmarks created on or after a date (YYYY-MM-DD), and before:<date> finds bookmarks created on or before a date (YYYY-MM-DD).
-If you need to pass names with spaces, you can quote them with double quotes. If you want to negate a qualifier, prefix it with a minus sign.
-## Examples:
-
-### Find favorited bookmarks from 2023 that are tagged "important"
-is:fav after:2023-01-01 before:2023-12-31 #important
-
-### Find archived bookmarks that are either in "reading" list or tagged "work"
-is:archived and (list:reading or #work)
-
-### Combine text search with qualifiers
-machine learning is:fav`),
+      query: z.string().describe(SEARCH_QUERY_LANGUAGE_DESCRIPTION),
       limit: z
         .number()
         .optional()

--- a/apps/mcp/src/search-query-docs.ts
+++ b/apps/mcp/src/search-query-docs.ts
@@ -1,0 +1,20 @@
+export const SEARCH_QUERY_LANGUAGE_DESCRIPTION = `
+Search bookmarks using Karakeep's query language. Combine free text terms with structured qualifiers to narrow results.
+
+Supported qualifiers include:
+- \`is:fav\`, \`is:archived\`, \`is:tagged\`, \`is:inlist\` for bookmark state
+- \`is:link\`, \`is:text\`, \`is:media\` to filter by bookmark type
+- \`url:<value>\` and \`title:<value>\` for substring matches (wrap multi-word values in double quotes)
+- \`#<tag>\` to match tags (supports double-quoted tag names with spaces)
+- \`list:<name>\` to target a list by name (exclude the icon; double quotes support spaces)
+- \`after:<YYYY-MM-DD>\` / \`before:<YYYY-MM-DD>\` to filter by creation date
+- \`feed:<name>\` to locate bookmarks imported from a feed
+- \`age:<comparison><value>\` to filter by relative age (use \`<\` or \`>\` with units \`d\`, \`w\`, \`m\`, or \`y\`)
+
+Prefix any qualifier with \`-\` to negate it. Combine multiple clauses with implicit AND, or use the explicit \`and\` / \`or\` keywords and parentheses for grouping when building complex queries.
+
+Example queries:
+- \`is:fav after:2023-01-01 before:2023-12-31 #important\`
+- \`is:archived and (list:reading or #work)\`
+- \`machine learning is:fav\`
+`;


### PR DESCRIPTION
## Summary
- limit level 1 debug logging by capping string lengths, shrinking collection previews, and bounding traversal depth so logs stay informative without overwhelming output
- add a shared search query language description that is reused by the MCP tool schema and OpenAPI generator to expose documentation from the project guides
- enrich the OpenAPI surface with detailed descriptions, tags, and examples to help Open WebUI discover the correct operations

## Testing
- pnpm --filter @karakeep/mcp typecheck
- pnpm --filter @karakeep/mcp lint

------
https://chatgpt.com/codex/tasks/task_e_68d3064207308324b0b10cbcd022ee3e