### PR TITLE
Add GET support for MCP OpenAPI bookmark search

### DIFF
--- a/apps/mcp/src/openapi.ts
+++ b/apps/mcp/src/openapi.ts
@@ -346,11 +346,86 @@ export function buildOpenApiSpec(basePath: string) {
     },
     paths: {
       "/bookmarks/search": {
-        post: {
+        get: {
           operationId: "searchBookmarks",
           summary: "Search bookmarks",
           tags: ["Bookmarks"],
           description: searchBookmarksOperationDescription,
+          parameters: [
+            {
+              name: "query",
+              in: "query",
+              required: false,
+              description:
+                "Search string written with Karakeep's query language. Defaults to an empty string when omitted.",
+              schema: { type: "string" },
+            },
+            {
+              name: "q",
+              in: "query",
+              required: false,
+              description:
+                "Alias for the query parameter used by legacy integrations.",
+              schema: { type: "string" },
+            },
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              description:
+                "Maximum number of bookmarks to return per page (default 10).",
+              schema: {
+                type: "integer",
+                minimum: 1,
+                maximum: 100,
+              },
+            },
+            {
+              name: "cursor",
+              in: "query",
+              required: false,
+              description:
+                "Cursor returned from a previous response to continue pagination.",
+              schema: { type: "string" },
+            },
+            {
+              name: "nextCursor",
+              in: "query",
+              required: false,
+              description:
+                "Alias for cursor for clients expecting a dedicated nextCursor field.",
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description:
+                "Paginated search results including bookmark summaries, cursors, and a human-readable summary string.",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/SearchBookmarksResult",
+                  },
+                },
+              },
+            },
+            default: {
+              description:
+                "Error response returned when the search request fails.",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+        post: {
+          operationId: "searchBookmarksPost",
+          summary: "Search bookmarks",
+          tags: ["Bookmarks"],
+          description: `${searchBookmarksOperationDescription}\n\nThis POST variant accepts a JSON request body and is kept for backwards compatibility.`,
+          deprecated: true,
           requestBody: {
             required: true,
             description:

--- a/tooling/mcp_openapi_check.py
+++ b/tooling/mcp_openapi_check.py
@@ -65,7 +65,9 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 
 
 def build_base_url(addr: str) -> str:
-    return addr.rstrip("/") + "/api/v1"
+    """Normalize the API base address without assuming a versioned suffix."""
+
+    return addr.rstrip("/")
 
 
 def fetch_openapi_spec(session: requests.Session, base_url: str, timeout: int) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- accept bookmark search requests over GET in the MCP OpenAPI server so Open WebUI style clients send real requests
- parse and normalize query parameters before reusing the existing search pipeline
- document the new GET variant in the generated OpenAPI schema and mark the legacy POST form as deprecated

## Testing
- `pnpm turbo run --no-daemon typecheck lint format`

------
https://chatgpt.com/codex/tasks/task_e_68d44ec34b1883249313f79134e64c7f