### PR TITLE
Improve bookmark search metadata to avoid context drift

### DIFF
--- a/apps/mcp/src/openapi.ts
+++ b/apps/mcp/src/openapi.ts
@@ -91,6 +91,9 @@ const searchBookmarksResultSchema = {
     "nextCursor",
     "cursor",
     "hasMore",
+    "submittedQuery",
+    "normalizedQuery",
+    "effectiveQuery",
     "data",
     "raw",
     "text",
@@ -124,6 +127,20 @@ const searchBookmarksResultSchema = {
       type: "boolean",
       description:
         "Indicates whether additional pages of results are available.",
+    },
+    submittedQuery: {
+      type: "string",
+      description: "Original query string supplied to the tool call.",
+    },
+    normalizedQuery: {
+      type: "string",
+      description:
+        "Lowercased and trimmed version of the submitted query used for internal normalization.",
+    },
+    effectiveQuery: {
+      type: "string",
+      description:
+        "Query string actually sent to the Karakeep API after normalization (e.g., wildcard substitutions).",
     },
     data: {
       type: "object",


### PR DESCRIPTION
## Summary
- include submitted, normalized, and effective query strings in the search bookmarks tool response
- expand the search-bookmarks tool summary to emphasise respecting the latest user request and surface the query metadata
- document the new metadata fields in the OpenAPI schema for the MCP search results

## Testing
- pnpm --filter @karakeep/mcp lint
- pnpm --filter @karakeep/mcp typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d459fb76708324ba795666d29c8028