### PR TITLE
fix: improve bookmark search defaults and tool output

### DIFF
--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -19,7 +19,7 @@ import {
 export const SearchBookmarksInputSchema = z
   .object({
     query: z.string(),
-    limit: z.number().int().positive().max(100).optional().default(10),
+    limit: z.number().int().positive().max(100).optional().default(100),
     nextCursor: z.string().nullable().optional(),
     cursor: z.string().nullable().optional(),
   })
@@ -147,7 +147,7 @@ export async function searchBookmarks(
 
   logDebug(2, "Search bookmarks raw response summary", {
     status: res.response?.status ?? null,
-    requestedLimit: input.limit ?? 10,
+    requestedLimit: input.limit ?? 100,
     returnedCount: rawBookmarks.length,
     nextCursor: res.data.nextCursor ?? null,
     cursor,
@@ -292,7 +292,7 @@ export function registerBookmarkTools(server: McpServer) {
         .number()
         .optional()
         .describe(`The number of results to return in a single query.`)
-        .default(10),
+        .default(100),
       nextCursor: z
         .string()
         .nullish()

--- a/apps/mcp/src/openapi.ts
+++ b/apps/mcp/src/openapi.ts
@@ -456,7 +456,7 @@ export function buildOpenApiSpec(basePath: string) {
                     value: {
                       query:
                         "is:fav after:2023-01-01 before:2023-12-31 #important",
-                      limit: 10,
+                      limit: 100,
                     },
                   },
                   machineLearning: {

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -307,27 +307,33 @@ export function formatBookmarkSearchResult(
   query?: string,
 ): string {
   if (bookmarks.length === 0) {
+    const header =
+      "Karakeep search-bookmarks tool response (not a user message):";
     const message = query
-      ? `No bookmarks matched the query "${query}".`
-      : "No bookmarks matched the current query.";
-    const cursorLine = `Next cursor: ${nextCursor ? `'${nextCursor}'` : "no more pages"}`;
-    return `${message}\n\n${cursorLine}`;
+      ? `- No bookmarks matched the query "${query}".`
+      : "- No bookmarks matched the current query.";
+    const cursorLine = `- Next cursor: ${
+      nextCursor ? `'${nextCursor}'` : "no more pages"
+    }.`;
+    return [header, message, cursorLine].join("\n");
   }
 
-  const introParts = [
-    `Found ${bookmarks.length} bookmark${bookmarks.length === 1 ? "" : "s"}.`,
+  const summaryLines = [
+    "Karakeep search-bookmarks tool response (not a user message):",
+    `- Found ${bookmarks.length} bookmark${bookmarks.length === 1 ? "" : "s"}.`,
   ];
   if (query && query.trim().length > 0) {
-    introParts.push(`Query: "${query}"`);
+    summaryLines.push(`- Query: "${query}".`);
   }
+  summaryLines.push(
+    `- Next cursor: ${nextCursor ? `'${nextCursor}'` : "no more pages"}.`,
+  );
 
   const formattedBookmarks = bookmarks
     .map((bookmark, index) => formatBookmarkLine(bookmark, index))
     .join("\n\n");
 
-  const cursorLine = `Next cursor: ${nextCursor ? `'${nextCursor}'` : "no more pages"}`;
-
-  return `${introParts.join(" ")}\n\n${formattedBookmarks}\n\n${cursorLine}`;
+  return `${summaryLines.join("\n")}\n\n${formattedBookmarks}`;
 }
 
 export interface ListSummary {


### PR DESCRIPTION
## Summary
- raise the default search limit for the MCP bookmark search schema and tool to 100 so follow-up page fetches return more items
- update the MCP OpenAPI example to reflect the higher default
- clarify the formatted search result text so tool responses are clearly labeled as tool output instead of looking like new user prompts

## Testing
- pnpm --filter @karakeep/mcp lint
- pnpm --filter @karakeep/mcp typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d46e24cfbc83249547f0a3e73ae23c