### PR TITLE
Virtualize bookmark grid and queue deletions

### DIFF
--- a/apps/web/components/dashboard/BulkBookmarksAction.tsx
+++ b/apps/web/components/dashboard/BulkBookmarksAction.tsx
@@ -169,18 +169,12 @@ export default function BulkBookmarksAction() {
     });
   };
 
-  const deleteBookmarks = async () => {
-    await Promise.all(
-      limitConcurrency(
-        selectedBookmarks.map(
-          (item) => () =>
-            deleteBookmarkMutator.mutateAsync({ bookmarkId: item.id }),
-        ),
-        MAX_CONCURRENT_BULK_ACTIONS,
-      ),
+  const deleteBookmarks = () => {
+    selectedBookmarks.forEach((item) =>
+      deleteBookmarkMutator.mutate({ bookmarkId: item.id }),
     );
     toast({
-      description: `${selectedBookmarks.length} bookmarks have been deleted!`,
+      description: `${selectedBookmarks.length} bookmarks queued for deletion!`,
     });
     setIsDeleteDialogOpen(false);
   };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -84,6 +84,7 @@
     "react-hook-form": "^7.57.0",
     "react-i18next": "^15.1.1",
     "react-intersection-observer": "^9.13.1",
+    "react-virtuoso": "^4.12.1",
     "react-markdown": "^9.0.1",
     "react-masonry-css": "^1.0.16",
     "react-select": "^5.10.1",


### PR DESCRIPTION
## Summary
- replace the bookmark grid rendering with react-virtuoso virtualization to limit the number of mounted cards while keeping all layouts working
- add a shared deletion queue so bookmark removals run sequentially in the background and update the bulk delete UX to enqueue work instead of waiting

## Testing
- pnpm --filter @karakeep/web lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e955cff88324b4d39691a11f6406